### PR TITLE
Construct websocket url based on protocol

### DIFF
--- a/public/MovieMatchAPI.js
+++ b/public/MovieMatchAPI.js
@@ -1,7 +1,7 @@
 export class MovieMatchAPI extends EventTarget {
   constructor() {
     super()
-    this.socket = new WebSocket(`ws://${location.host}/ws`)
+    this.socket = new WebSocket(`${location.protocol === 'https:' ? 'wss' : 'ws'}://${location.host}/ws`)
     this.socket.addEventListener('message', e => this.handleMessage(e))
 
     this._movieList = []


### PR DESCRIPTION
Use `location.protocol` to determine if we can use secure websockets. Useful if app sits behind a reverse proxy that has an SSL cert, e.g. https://moviematch.example.com