### PR TITLE
remove nullish coalescing operator for mobile browser compatibility

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -50,10 +50,10 @@ const main = async () => {
     topCardEl = topCardEl.nextSibling
 
     if (!topCardEl) {
-      document
-        .querySelector('.js-card-stack')
-        ?.style.setProperty('--empty-text', `var(--i18n-exhausted-cards)`)
-
+      const cardStack = document.querySelector('.js-card-stack');
+      if (cardStack) {
+        cardStack.style.setProperty('--empty-text', `var(--i18n-exhausted-cards)`)
+      }
       rateControls.setAttribute('disabled', '')
     }
   })


### PR DESCRIPTION
The nullish coalescing operator is not available on some mobile browsers and it breaks the entire app for those browsers. This fix removes the operator and adds the truthy if statement which does the same thing.